### PR TITLE
Remove chunked encoding from patches

### DIFF
--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -302,7 +302,7 @@ Table of Contents
 
 
    In order to distinguish each patch within a Version, we need to know
-   the length of each patch.  To know the length of each patch, it must
+   the length of each patch.  To know the length of each patch, it MUST
    include the following header:
 
          Content-Length: N
@@ -500,8 +500,8 @@ Table of Contents
 
    To send multiple updates, a server concatenates multiple
    sub-responses into a single response body.  Each sub-response must
-   contain its own headers and body.  Each sub-response must have a
-   known length, which means it must contain one of the following
+   contain its own headers and body.  Each sub-response MUST have a
+   known length, which means it MUST contain one of the following
    headers:
 
       - Content-Length: N

--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -302,7 +302,7 @@ Table of Contents
 
 
    In order to distinguish each patch within a Version, we need to know
-   the length of each patch.  To know the length of each past, it must
+   the length of each patch.  To know the length of each patch, it must
    include the following header:
 
          Content-Length: N

--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -302,14 +302,12 @@ Table of Contents
 
 
    In order to distinguish each patch within a Version, we need to know
-   the length of the patch.  To know the length of the patch, each patch
-   must include one of the following headers:
+   the length of each patch.  To know the length of each past, it must
+   include the following header:
 
          Content-Length: N
-         Transfer-Encoding: chunked
 
-   Either of these provide a way to determine when the next message
-   starts.
+   This length determines where this patch ends, and next begins.
 
 
    The previous example uses the Range Patch format, which is defined in


### PR DESCRIPTION
Although `Content-Encoding: chunked` could conceivably be used to distinguish the starts and ends of patches, [Karel points out that it's strange to have two levels of chunked encoding](https://groups.google.com/g/braid-http/c/9WNt33jvfts), and we don't actually have any motivating examples where one would need `chunked` instead of the simpler `Content-Length: N`.

In HTTP, chunked encoding is useful when you don't know the full length of a message body ahead of time, for instance when you want to stream a large file. However, I'm not aware of any situations in which we need to stream a large patch.

Until we run across such situations, it seems reasonable to just remove `Transfer-Encoding: chunked` from the spec for Patches.

(This PR does not remove `Transfer-Encoding: chunked` from Versions; just Patches.)