### PR TITLE
Use `$link` instead of `link` in linked-json spec

### DIFF
--- a/draft-toomim-httpbis-linked-json-00.txt
+++ b/draft-toomim-httpbis-linked-json-00.txt
@@ -70,11 +70,11 @@ Table of Contents
 
 1.1.  Syntax
 
-   A Link is encoded as a JSON object with a field named "link":
+   A Link is encoded as a JSON object with a field named "$link":
 
-     { "link": "/david-macaulay" }
+     { "$link": "/david-macaulay" }
 
-   Any object with a field named "link" is interpreted as a Link.  The
+   Any object with a field named "$link" is interpreted as a Link.  The
    value of the link field MUST be a string containing a URI [RFC3986].
 
    Links MAY be embedded within arbitrary JSON:
@@ -87,13 +87,13 @@ Table of Contents
 
 1.2.  Escaping
 
-   To encode a field named "link" *without* creating a Link, prefix the
+   To encode a field named "$link" *without* creating a Link, prefix the
    field with an underscore:
 
-     { "_link": "this is not a link" }
+     { "\\$link": "this is not a link" }
 
-   To encode "_link", prefix it with two underscores: "__link".  To
-   encode "__link", use "___link", and so on.
+   To encode "\\$link", prefix it with four backslashes: "\\\\$link".  And
+   so on.
 
 1.3.  Metadata
 
@@ -114,7 +114,7 @@ Table of Contents
 
    Or a GraphQL [GRAPHQL] query:
 
-     { "link": "/foo", "range": "(bar:9)[3,4]" }
+     { "$link": "/foo", "range": "(bar:9)[3,4]" }
 
 
 2.  Related Work
@@ -122,10 +122,10 @@ Table of Contents
    See [MNOT] for a survey of related work.  Linked JSON is most similar
    to [JSONREF], but has the following differences:
 
-     - It names the special field "link" instead of "$ref".
+     - It names the special field "$link" instead of "$ref".
 
      - It provides an escape hatch for when users need to encode the
-       string "link".
+       string "$link".
 
      - It allows metadata to be specified on links.
 


### PR DESCRIPTION
Prefer a special character to denote special meaning.

See https://github.com/braid-work/braid-spec/issues/78