### PR TITLE
Added comment about specific version requests being optional

### DIFF
--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -353,8 +353,6 @@ Table of Contents
    of a resource in GET requests.  To request a historical version, a
    client includes a Version and/or Parents header in the request.
 
-   Servers MAY support handling all specific version requests, or just a
-   subset of specific version requests.
 
       Request:
 
@@ -372,7 +370,7 @@ Table of Contents
                                                                |
          [{"text": "Hi, everyone!",                            | | Body
            "author": {"link": "/user/tommy"}}]                 | |
-   
+
 
    If a GET request contains a Version header:
 
@@ -404,7 +402,24 @@ Table of Contents
    A server MAY refactor or rebase the version history that it provides
    to a client, so long as it does not affect the resulting state, or
    the result of the patch-type's merges.
-
+
+   A server does not need to honor historical version requests for all
+   documents, for all history. If a server no longer has the historical
+   context needed to honor a request, it may respond using the 416 Range
+   Not Satisfiable status code. (Defined in [RFC7233], Section 4.4)
+
+
+      Request:
+
+         GET /chat
+         Version: "ej4lhb9z78"
+
+      Response:
+
+         HTTP/1.1 416 Range Not Satisfiable
+         Version: "ej4lhb9z78"
+
+
 
 3.  Subscriptions for GET
 

--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -353,6 +353,8 @@ Table of Contents
    of a resource in GET requests.  To request a historical version, a
    client includes a Version and/or Parents header in the request.
 
+   Servers MAY support handling all specific version requests, or just a
+   subset of specific version requests.
 
       Request:
 

--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -405,8 +405,8 @@ Table of Contents
 
    A server does not need to honor historical version requests for all
    documents, for all history. If a server no longer has the historical
-   context needed to honor a request, it may respond using the 416 Range
-   Not Satisfiable status code. (Defined in [RFC7233], Section 4.4)
+   context needed to honor a request, it may respond using an error code
+   which will be defined in a subsequent version of this RFC draft.
 
 
       Request:
@@ -416,7 +416,7 @@ Table of Contents
 
       Response:
 
-         HTTP/1.1 416 Range Not Satisfiable
+         HTTP/1.1 XXX
          Version: "ej4lhb9z78"
 
 


### PR DESCRIPTION
The current spec implies the server must either support requesting all historical versions or none of them. We should make it clear servers can support all, none or some historical version requests based on implementation details.

My language here feels awkward.