### PR TITLE
Added wording to the spec allow extra newlines between resources

### DIFF
--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -275,7 +275,7 @@ Table of Contents
    One can send an update in a patch by setting the "Patches" header to
    a number, and then set the Message body to a sequence of that many
    patches, separated by blank lines:
-
+
 
       Request:
 
@@ -370,7 +370,7 @@ Table of Contents
                                                                |
          [{"text": "Hi, everyone!",                            | | Body
            "author": {"link": "/user/tommy"}}]                 | |
-   
+
 
    If a GET request contains a Version header:
 
@@ -504,13 +504,19 @@ Table of Contents
    headers:
 
       - Content-Length: N
-      - Transfer-Encoding: chunked
       - Patches: N
 
    Each sub-response must have both headers and a body.  The body may be
    zero-length.
 
-
+   The server MAY insert any number of extra newlines between the end of
+   one sub-resource and the beginning of the next. If present, these
+   newline characters are not included in the preceeding body and thus
+   they will not be included in the preceeding header's Content-Length.
+   Extra newlines may be encoded using either the \r\n ASCII character
+   pair or using a single \n character.
+
+
 
 3.3.  Continuing a Subscription
 

--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -509,12 +509,14 @@ Table of Contents
    Each sub-response must have both headers and a body.  The body may be
    zero-length.
 
-   The server MAY insert any number of extra newlines between the end of
-   one sub-resource and the beginning of the next. If present, these
-   newline characters are not included in the preceeding body and thus
-   they will not be included in the preceeding header's Content-Length.
-   Extra newlines may be encoded using either the \r\n ASCII character
-   pair or using a single \n character.
+   To prevent browsers (and other clients) from closing inactive
+   connections, the server MAY insert any number of extra newlines
+   between the end of one sub-response and the beginning of the next. If
+   present, these newline characters do not constitute part of the
+   preceding body, and thus their length is not included in the
+   preceding header's Content-Length. Any extra newlines may be encoded
+   using either the \r\n ASCII character pairs or singular \n
+   characters.
 
 
 


### PR DESCRIPTION
This PR fixes #73 as per the discussion we had at meeting 6.