### PR TITLE
Rename `Content-*` → `Patch-*` within Patches

### DIFF
--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -297,14 +297,14 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 2                                         |
                                                             |
-         Patch-Length: 53                                   | | Patch
-         Range: json=.messages[1:1]                         | |
+         Patch-Range: json .messages[1:1]                   | | Patch
+         Patch-Length: 53                                   | |
                                                             | |
          [{"text": "Yo!",                                   | |
            "author": {"link": "/user/yobot"}]               | |
                                                             |
-         Patch-Length: 40                                   | | Patch
-         Range: json=.latest_change                         | |
+         Patch-Range: json .latest_change                   | | Patch
+         Patch-Length: 40                                   | |
                                                             | |
          {"type": "date", "value": 1573952202370}           | |
 
@@ -340,8 +340,8 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Patch-Length: 288                                  | | Patch
-         Patch-Type: application/json-patch+json            | |
+         Patch-Type: application/json-patch+json            | | Patch
+         Patch-Length: 288                                  | |
                                                             | |
          [                                                  | |
           {"op": "test", "path": "/a/b/c", "value": "foo"}, | |
@@ -467,8 +467,8 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Patch-Length: 53                                   | | Patch
-         Content-Range: json .messages[1:1]                 | |
+         Patch-Range: json .messages[1:1]                   | | Patch
+         Patch-Length: 53                                   | |
                                                             | |
          [{"text": "Yo!",                                   | |
            "author": {"link": "/user/yobot"}]               | |
@@ -479,8 +479,8 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Patch-Length: 58                                   | | Patch
-         Content-Range: json .messages[2:2]                 | |
+         Patch-Range: json .messages[2:2]                   | | Patch
+         Patch-Length: 58                                   | |
                                                             | |
          [{"text": "Hi, Tommy!",                            | |
            "author": {"link": "/user/sal"}}]                | |
@@ -491,8 +491,8 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Patch-Length: 288                                  | | Patch
-         Patch-Type: application/json-patch+json            | |
+         Patch-Type: application/json-patch+json            | | Patch
+         Patch-Length: 288                                  | |
                                                             | |
          [                                                  | |
           {"op": "test", "path": "/a/b/c", "value": "foo"}, | |
@@ -597,8 +597,8 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Patch-Length: 53                                   | | Patch
-         Content-Range: json .messages[1:1]                 | |
+         Patch-Range: json .messages[1:1]                   | | Patch
+         Patch-Length: 53                                   | |
                                                             | |
          [{"text": "Yo!",                                   | |
            "author": {"link": "/user/yobot"}]               | |
@@ -687,13 +687,13 @@ Table of Contents
        Content-Type: image/png         | Update
        Patches: 2                      |
                                        |
-       Patch-Length: 1239              | | Patch
-       Content-Range: bytes 100-200    | |
+       Patch-Range: bytes 100-200      | | Patch
+       Patch-Length: 1239              | |
                                        | |
        <binary data>                   | |
                                        |
-       Patch-Length: 62638             | | Patch
-       Content-Range: bytes 348-887    | |
+       Patch-Range: bytes 348-887      | | Patch
+       Patch-Length: 62638             | |
                                        | | 
        <binary data>                   | |
 

--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -297,13 +297,13 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 2                                         |
                                                             |
-         Content-Length: 53                                 | | Patch
+         Patch-Length: 53                                   | | Patch
          Range: json=.messages[1:1]                         | |
                                                             | |
          [{"text": "Yo!",                                   | |
            "author": {"link": "/user/yobot"}]               | |
                                                             |
-         Content-Length: 40                                 | | Patch
+         Patch-Length: 40                                   | | Patch
          Range: json=.latest_change                         | |
                                                             | |
          {"type": "date", "value": 1573952202370}           | |
@@ -318,14 +318,14 @@ Table of Contents
    To distinguish the boundaries between patches in an Update, each
    patch MUST include the following header:
 
-         Content-Length: N
+         Patch-Length: N
 
    This length determines where each patch ends, and next begins.
 
 
    The previous example uses the Range Patch format, which is defined in
    [RANGE-PATCH].  However, one can use any patch format, by sending a
-   patch with a Content-Type set to a patch format with a defined
+   patch with a Patch-Type header set to a patch format with a defined
    behavior, such as application/json-patch+json (as specified in
    [RFC6902]):
 
@@ -340,8 +340,8 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Content-Length: 288                                | | Patch
-         Content-Type: application/json-patch+json          | |
+         Patch-Length: 288                                  | | Patch
+         Patch-Type: application/json-patch+json            | |
                                                             | |
          [                                                  | |
           {"op": "test", "path": "/a/b/c", "value": "foo"}, | |
@@ -358,7 +358,7 @@ Table of Contents
          Patches: OK
 
 
-   Every patch MUST include either a Content-Type or a Content-Range.
+   Every patch MUST include either a Patch-Type or a Content-Range.
 
 
 2.4.  GET a specific version
@@ -467,7 +467,7 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Content-Length: 53                                 | | Patch
+         Patch-Length: 53                                   | | Patch
          Content-Range: json .messages[1:1]                 | |
                                                             | |
          [{"text": "Yo!",                                   | |
@@ -479,7 +479,7 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Content-Length: 58                                 | | Patch
+         Patch-Length: 58                                   | | Patch
          Content-Range: json .messages[2:2]                 | |
                                                             | |
          [{"text": "Hi, Tommy!",                            | |
@@ -491,8 +491,8 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Content-Length: 288                                | | Patch
-         Content-Type: application/json-patch+json          | |
+         Patch-Length: 288                                  | | Patch
+         Patch-Type: application/json-patch+json            | |
                                                             | |
          [                                                  | |
           {"op": "test", "path": "/a/b/c", "value": "foo"}, | |
@@ -530,7 +530,7 @@ Table of Contents
 
    To send multiple updates, a server concatenates multiple updates into
    a single response body.  Each update MUST include headers and a body,
-   and MUST specify the end of its body by including at least one of the
+   and MUST define the end of its body by including at least one of the
    following headers:
 
       - Content-Length: N
@@ -597,7 +597,7 @@ Table of Contents
          Merge-Type: sync9                                  |
          Patches: 1                                         |
                                                             |
-         Content-Length: 53                                 | | Patch
+         Patch-Length: 53                                   | | Patch
          Content-Range: json .messages[1:1]                 | |
                                                             | |
          [{"text": "Yo!",                                   | |
@@ -687,12 +687,12 @@ Table of Contents
        Content-Type: image/png         | Update
        Patches: 2                      |
                                        |
-       Content-Length: 1239            | | Patch
+       Patch-Length: 1239              | | Patch
        Content-Range: bytes 100-200    | |
                                        | |
        <binary data>                   | |
                                        |
-       Content-Length: 62638           | | Patch
+       Patch-Length: 62638             | | Patch
        Content-Range: bytes 348-887    | |
                                        | | 
        <binary data>                   | |


### PR DESCRIPTION
## Draft Renaming Scheme for Issue #97

Synopsis of the issue:
- We originally re-used HTTP's top-level `Content-Length`, `Content-Type`, and `Content-Range` headers to describe patches
- But we noticed they read clearer as `Patch-Length`, `Patch-Type`, and `Patch-Range` in subscriptions
  - Semantically, these are more about "patches" than "content"
  - Patch-* more clearly separates the second level of patch headers from top-level Content-* headers
- I'm hesitant to clobber or make redundant HTTP's existing Content-* headers at top-level
- Question: How do we reconcile Patch-* with the top-level Content-* headers?
  - Consider: The common case of `Patches: 1` is equivalent to a top-level HTTP patch

This PR proposes a naming rule, illustrates it with examples, and provides edits to the spec to support it.

### The Proposed Rule

Updates expressed at the **top level** of PUT and GET use existing HTTP headers (except Patch-Type, which is new):

  - Content-Length
  - Content-Range
  - Patch-Type

Updates expressed **within** a `Patches: N` block use the Patch-* variant:

  - Patch-Length
  - Patch-Range
  - Patch-Type

The PATCH method continues to use Content-Type instead of Patch-Type.

### Advantages
  - Preserves existing HTTP rules for top-level Partial PUT
  - Simple to convert from top-level into a `Patches: N` block
    - [`Patches: N` avoids corrupting legacy servers with Partial PUT](https://github.com/braid-org/braid-spec/issues/117)
  - Patch-level headers are visually distinguished from top-level headers

## Examples

### Range Patch with PUT at top level

         PUT /chat
         Content-Type: application/json
         Content-Range: json .messages[1:1]
         Content-Length: 189

         [{"text": "Yo!",
           "author": {"link": "/user/yobot"}]

Notes:
 - Uses `Content-*` uniformly.
 - Requires prior knowledge or [feature detection](https://github.com/braid-org/braid-spec/issues/89) on legacy servers.

### Range Patch with PUT within a `Patches: 1` block

         PUT /chat
         Content-Type: application/json
         Patches: 1

         Patch-Range: json .messages[1:1]
         Patch-Length: 189

         [{"text": "Yo!",
           "author": {"link": "/user/yobot"}]

Notes:
 - Uses `Patch-*` uniformly.
 - [Safe on legacy servers](https://github.com/braid-org/braid-spec/issues/117).

### Custom Patch Type at top-level using `PATCH`

         PATCH /chat
         Content-Type: text/json-ot
         Content-Length: 8

         [0, 'n']

Notes:
 - Unchanged.
 - Safe on legacy servers.

### Custom Patch Type with PUT at top-level

         PUT /chat
         Content-Type: application/json
         Patch-Type: text/json-ot
         Content-Length: 8

         [0, 'n']

Note:
 - Requires prior knowledge or [feature detection](https://github.com/braid-org/braid-spec/issues/89) on legacy servers.

### Custom Patch Type using PUT within `Patches: 1`:

         PUT /chat
         Content-Type: application/json
         Patches: 1

         Patch-Type: text/json-ot
         Patch-Length: 8

         [0, 'n']

Note:
 - Safe on legacy servers

### GET Subscription with `Patches: N` blocks

         HTTP/1.1 209 Subscription
         Subscribe:
         Version: "g09ur8z74r"                              | Update
         Parents: "ej4lhb9z78"                              |
         Content-Type: application/json                     |
         Merge-Type: sync9                                  |
         Patches: 1                                         |
                                                            |
         Patch-Range: json .messages[1:1]                   | | Patch
         Patch-Length: 53                                   | |
                                                            | |
         [{"text": "Yo!",                                   | |
           "author": {"link": "/user/yobot"}]               | |

         Version: "2bcbi84nsp"                              | Update
         Parents: "g09ur8z74r"                              |
         Content-Type: application/json                     |
         Merge-Type: sync9                                  |
         Patches: 1                                         |
                                                            |
         Patch-Range: json .messages[2:2]                   | | Patch
         Patch-Length: 58                                   | |
                                                            | |
         [{"text": "Hi, Tommy!",                            | |
           "author": {"link": "/user/sal"}}]                | |

Note:
 - Uses `Patch-*` uniformly for all the patch information.

### GET Subscription with snapshots

         HTTP/1.1 209 Subscription
         Subscribe:
         Version: "ej4lhb9z78"                              | Update
         Parents: "oakwn5b8qh", "uc9zwhw7mf"                |
         Content-Type: application/json                     |
         Merge-Type: sync9                                  |
         Content-Length: 64                                 |
                                                            |
         [{"text": "Hi, everyone!",                         | | Snapshot
           "author": {"link": "/user/tommy"}}]              | |

         Version: "g2hd8asdf6"                              | Update
         Parents: "ej4lhb9z78"                              |
         Content-Type: application/json                     |
         Merge-Type: sync9                                  |
         Content-Length: 63                                 |
                                                            |
         [{"text": "Hi, someone!",                          | | Snapshot
           "author": {"link": "/user/tommy"}}]              | |

Note:
 - Uses `Content-*` uniformly.

### GET responding with Custom Patch Type in `Patches: N` block

         HTTP/1.1 200 OK
         Version: "up12vyc5ib"                              | Update
         Parents: "2bcbi84nsp"                              |
         Content-Type: application/json                     |
         Merge-Type: sync9                                  |
         Patches: 1                                         |
                                                            |
         Patch-Type: application/json-patch+json            | | Patch
         Patch-Length: 288                                  | |
                                                            | |
         [                                                  | |
          {"op": "test", "path": "/a/b/c", "value": "foo"}, | |
          {"op": "remove", "path": "/a/b/c"},               | |
          {"op": "add", "path": "/a/b/c", "value": []},     | |
          {"op": "replace", "path": "/a/b/c", "value": 42}, | |
          {"op": "move", "from": "/a/b", "path": "/a/d"},   | |
          {"op": "copy", "from": "/a/d", "path": "/a/d/e"}  | |
         ]                                                  | |

Note:
 - Uses `Patch-*` uniformly for all the patch information.

### GET responding with Custom Patch Type at top level

Note: Impossible, because `Content-Type` clobbers.

## Comparisons with current spec

### Range Patch with PUT at top-level

         PUT /chat
         Content-Type: application/json
         Content-Range: json .messages[1:1]
         Content-Length: 189

         [{"text": "Yo!",
           "author": {"link": "/user/yobot"}]

Notes:
 - Unchanged.
 - Requires prior knowledge or [feature detection](https://github.com/braid-org/braid-spec/issues/89) on legacy servers.


### Range Patch with PUT within `Patches: 1` block

         PUT /chat
         Content-Type: application/json
         Patches: 1

         Content-Range: json .messages[1:1]
         Content-Length: 189

         [{"text": "Yo!",
           "author": {"link": "/user/yobot"}]

Notes:
 - Uses the same `Content-*` as top-level patches in previous example.
 - Safe on legacy servers.

### Custom Patch Type with PUT is Impossible

Note: Impossible, because `Content-Type` clobbers:

         PUT /chat
         Content-Type: application/json        <-- Type of the /chat resource
         Content-Type: text/json-ot            <-- Type of the custom patch format
         Content-Length: 8

         [0, 'n']

### Custom Patch Type with PATCH

         PATCH /chat
         Content-Type: text/json-ot
         Content-Length: 8

         [0, 'n']

Notes:
 - Unchanged.
 - Safe on legacy servers.

### Custom Patch Type within a `Patches: 1` block

Uses Content-*

         PUT /chat
         Content-Type: application/json
         Patches: 1

         Content-Type: text/json-ot
         Content-Length: 8

         [0, 'n']

Notes:
 - Safe on legacy servers.

Thoughts?