### PR TITLE
Remove blank line after subscription headers

### DIFF
--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -451,7 +451,6 @@ Table of Contents
 
          HTTP/1.1 209 Subscription
          Subscribe: keep-alive
-
          Version: "ej4lhb9z78"                              | Update
          Parents: "oakwn5b8qh", "uc9zwhw7mf"                |
          Content-Type: application/json                     |
@@ -528,10 +527,11 @@ Table of Contents
 
 3.2.  Sending multiple updates per GET
 
-   To send multiple updates, a server concatenates multiple updates into
-   a single response body.  Each update MUST include headers and a body,
-   and MUST specify the end of its body by including at least one of the
-   following headers:
+   To send multiple updates, a server sends the first update as usual,
+   but then leaves the connection open, and appends additional updates
+   to the end of the response body.  Each update MUST include headers
+   and a body, and MUST specify the end of its body by including at
+   least one of the following headers:
 
       - Content-Length: N
       - Patches: N
@@ -570,7 +570,6 @@ Table of Contents
 
          HTTP/1.1 209 Subscription
          Subscribe: keep-alive
-
          Version: "ej4lhb9z78"                              | Update
          Content-Type: application/json                     |
          Content-Length: 64                                 |
@@ -590,7 +589,6 @@ Table of Contents
 
          HTTP/1.1 209 Subscription
          Subscribe: keep-alive
-
          Version: "g09ur8z74r"                              | Update
          Parents: "ej4lhb9z78"                              |
          Content-Type: application/json                     |
@@ -624,8 +622,7 @@ Table of Contents
 
          HTTP/1.1 209 Subscription
          Subscribe: keep-alive
-         Current-Version: "ej4lhb9z78"               <-- Current Version
-
+         Current-Version: "ej4lhb9z78"             | <-- Current Version
          Version: "b9z78ej4lh"                     | Updates
          Content-Type: application/json            |
          Merge-Type: sync9                         |


### PR DESCRIPTION
This implements https://github.com/braid-org/braid-spec/issues/85, and clarifies that there are only two levels of message framing in Braid subscriptions:

1. **Updates**
2. **Patches**

See https://github.com/braid-org/braid-spec/issues/85#issuecomment-1685374641