### PR TITLE
Specify patch types with `Patch-Type` instead of `Content-Type`

### DIFF
--- a/draft-toomim-httpbis-braid-http-03.txt
+++ b/draft-toomim-httpbis-braid-http-03.txt
@@ -315,9 +315,9 @@ Table of Contents
 
    The previous example uses the Range Patch format, which is defined in
    [RANGE-PATCH].  However, one can use any patch format, by sending a
-   patch with a Content-Type set to a patch format with a defined
-   behavior, such as application/json-patch+json (as specified in
-   [RFC6902]):
+   patch with a Patch-Type set to a content-type with a defined behavior
+   for the HTTP PATCH method, such as application/json-patch+json (as
+   specified in [RFC6902]):
 
 
       Request:
@@ -331,7 +331,7 @@ Table of Contents
          Patches: 1                                            |
                                                                |
          Content-Length: 326                                   | | Patch
-         Content-Type: application/json-patch+json             | |
+         Patch-Type: application/json-patch+json               | |
                                                                | |
          [                                                     | |
            { "op": "test", "path": "/a/b/c", "value": "foo" }, | |
@@ -347,7 +347,7 @@ Table of Contents
          HTTP/1.1 200 OK
          Patches: OK
 
-   Every patch MUST include either a Content-Type or a Content-Range.
+   Every patch MUST include either a Patch-Type or a Content-Range.
 
 
 2.4.  GET a specific version
@@ -481,7 +481,7 @@ Table of Contents
          Patches: 1                                            |
                                                                |
          Content-Length: 326                                   | | Patch
-         Content-Type: application/json-patch+json             | |
+         Patch-Type: application/json-patch+json               | |
                                                                | |
          [                                                     | |
            { "op": "test", "path": "/a/b/c", "value": "foo" }, | |


### PR DESCRIPTION
The spec currently specifies custom patch types in the same way that the HTTP PATCH method does: using the `Content-Type` header.

But this sucks, because it clobbers other uses of Content-Type that we care about.
 - We can't allow an actual Content-Type to exist in the same message as a patch type expressed as Content-Type
 - We can't use Content-Type to specify the Patch Type in a place where Content-Type already means something (like a GET response)

This rules out these use-cases:
- A client creating a resource with a patch can't specify the content-type of the resource it wants to create
- A client editing a resource with multiple representations (e.g. `text/markdown` that gets rendered into `application/html`), can't specify which representation it wants its patch to apply to
- A server can't return a custom patch type in a GET response, without wrapping it in a `Patches: N`, where there is not existing definition of content-type.

So I propose that we ignore how PATCH does things, and introduce an actual `Patch-Type` header for patch types. This PR makes the change. We only need to change 6 lines.

(More context in https://braid.org/meeting-69/http-patch-design)